### PR TITLE
required newline in some shells

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func main() {
 
 	t, err := prompter.Selection()
 	if err != nil {
-		fmt.Printf("%s\n", err.Error())
+		fmt.Printf("%s", err.Error())
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -39,19 +39,19 @@ func main() {
 		p, err = pages.Read(*page)
 	}
 	if err != nil {
-		fmt.Printf("%s", err.Error())
+		fmt.Printf("%s\n", err.Error())
 		return
 	}
 
 	prompter := prompt.New(p)
 	if err = prompter.RenderPage(*static); err != nil {
-		fmt.Printf("%s", err.Error())
+		fmt.Printf("%s\n", err.Error())
 		return
 	}
 
 	t, err := prompter.Selection()
 	if err != nil {
-		fmt.Printf("%s", err.Error())
+		fmt.Printf("%s\n", err.Error())
 		return
 	}
 
@@ -61,12 +61,12 @@ func main() {
 
 	cmd, err := prompter.GenerateCommand(t)
 	if err != nil {
-		fmt.Printf("%s", err.Error())
+		fmt.Printf("%s\n", err.Error())
 		return
 	}
 
 	if err = prompter.Run(cmd); err != nil {
-		fmt.Printf("%s", err.Error())
+		fmt.Printf("%s\n", err.Error())
 		return
 	}
 }


### PR DESCRIPTION
Adds a new line to error output. Tested in bash and zsh on linux.

**Screen shots of behavior before this commit in zsh:**
![2019-01-19-12-18-12_screenshot](https://user-images.githubusercontent.com/10411242/51431485-acf9f080-1be6-11e9-9bf8-35b32f165d34.png)


![2019-01-19-12-18-43_screenshot](https://user-images.githubusercontent.com/10411242/51431486-acf9f080-1be6-11e9-814c-e36a8788f7a6.png)

**Screenshots after this commit:**
![2019-01-19-12-19-46_screenshot](https://user-images.githubusercontent.com/10411242/51431487-ad928700-1be6-11e9-97bd-dfd656e0ef5e.png)


![2019-01-19-12-20-22_screenshot](https://user-images.githubusercontent.com/10411242/51431488-ad928700-1be6-11e9-8cca-0da099eb2da6.png)
